### PR TITLE
🐛  Checking image diff result for null

### DIFF
--- a/controllers/repositories/repositoryDetails.js
+++ b/controllers/repositories/repositoryDetails.js
@@ -252,9 +252,11 @@ async function fetchImageCaptureDiff(owner, repository, branch, dependencies) {
     };
   } else {
     return {
-      newCount: latest.raw_json.new.length,
-      changedCount: latest.raw_json.changed.length,
-      removedCount: latest.raw_json.removed.length,
+      newCount: latest.raw_json.new != null ? latest.raw_json.new.length : 0,
+      changedCount:
+        latest.raw_json.changed != null ? latest.raw_json.changed.length : 0,
+      removedCount:
+        latest.raw_json.removed != null ? latest.raw_json.removed.length : 0,
     };
   }
 }


### PR DESCRIPTION
This PR fixes a bug when no image diff was found.

closes #47 
