### PR TITLE
🐛  fixed number of columns on image gallery diff page

### DIFF
--- a/views/repositories/imageCaptureDiffDetails.pug
+++ b/views/repositories/imageCaptureDiffDetails.pug
@@ -18,7 +18,7 @@ block content
             div(class="bg-white border-transparent rounded-lg shadow-lg")
                 div(class="bg-gray-400 uppercase text-gray-800 border-b-2 border-gray-500 rounded-tl-lg rounded-tr-lg p-2")
                     h5(class="font-bold uppercase text-gray-600") Changed Images
-                div(class="p-5 grid grid-cols-3 gap-4 bg-gray-800")
+                div(class="p-5 grid grid-cols-2 gap-4 bg-gray-800")
                     each image, i in images.changed
                         a(href=``+image.base.url)
                             h1(class="text-white")= ``+image.base.title+` BEFORE`


### PR DESCRIPTION
This PR changes the number of columns on the image gallery diff page to 2 instead of 3. Now the before/after will show up side by side.

closes #49 
